### PR TITLE
Remove permission for "your browsing history"

### DIFF
--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -9,7 +9,6 @@
 
   "permissions": [
     "storage",
-    "tabs",
     "https://trello.com/*"
   ],
 


### PR DESCRIPTION
The "tabs" permission triggers the "your browser history" line in the permissions dialog.
